### PR TITLE
DEVOPS-97 burnrate (re)builds pricing table once per 24 hours from live AmazonEC2 offers download

### DIFF
--- a/calculate_burn_rate.py
+++ b/calculate_burn_rate.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2014-2015 Numenta Inc.
+# Copyright 2014-2016 Numenta Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,103 +16,81 @@
 #
 
 """ This script calculates various metrics related to AWS hourly burn rate."""
+
+import shutil
 import os
+import sys
+import tempfile
+import time
+
 import boto
 import boto.exception
 from boto.ec2 import regions
 
-# Prices last updated 11/14/14
-# These are the prices for On-Demand Instances
-COST_MATRIX = {
-                "us-east-1": {
-                  "c1.medium": 0.13,
-                  "c1.xlarge": 0.52,
-                  "c3.large": 0.105,
-                  "c3.xlarge": 0.21,
-                  "c3.2xlarge": 0.42,
-                  "c3.4xlarge": 0.84,
-                  "c3.8xlarge": 1.68,
-                  "cc2.8xlarge": 2.00,
-                  "cg1.4xlarge": 2.1,
-                  "cr1.8xlarge": 3.5,
-                  "g2.2xlarge": 0.65,
-                  "hi1.4xlarge": 3.1,
-                  "hs1.8xlarge": 4.6,
-                  "i2.xlarge": 0.853,
-                  "i2.2xlarge": 1.705,
-                  "i2.4xlarge": 3.41,
-                  "i2.8xlarge": 6.82,
-                  "m1.small": 0.044,
-                  "m1.medium": 0.087,
-                  "m1.large": 0.175,
-                  "m1.xlarge": 0.350,
-                  "m2.xlarge": 0.245,
-                  "m2.2xlarge": 0.49,
-                  "m2.4xlarge": 0.98,
-                  "m3.medium": 0.07,
-                  "m3.large": 0.14,
-                  "m3.xlarge": 0.280,
-                  "m3.2xlarge": 0.560,
-                  "r3.large": 0.175,
-                  "r3.xlarge": 0.35,
-                  "r3.2xlarge": 0.7,
-                  "r3.4xlarge": 1.4,
-                  "r3.8xlarge": 2.8,
-                  "t1.micro": 0.02,
-                  "t2.micro": 0.013,
-                  "t2.small": 0.026,
-                  "t2.medium": 0.052,
-                },
-                "us-west-2": {
-                  "c1.medium": 0.13,
-                  "c1.xlarge": 0.52,
-                  "cc2.8xlarge": 2.0,
-                  "c3.large": 0.105,
-                  "c3.xlarge": 0.21,
-                  "c3.2xlarge": 0.42,
-                  "c3.4xlarge": 0.84,
-                  "c3.8xlarge": 1.68,
-                  "cr1.8xlarge": 3.5,
-                  "g2.2xlarge": 0.65,
-                  "hs1.8xlarge": 4.6,
-                  "h1.4xlarge": 3.1,
-                  "i2.xlarge": 0.853,
-                  "i2.2xlarge": 1.705,
-                  "i2.4xlarge": 3.41,
-                  "i2.8xlarge": 6.82,
-                  "r3.large": 0.175,
-                  "r2.xlarge": 0.35,
-                  "r2.2xlarge": 0.7,
-                  "r2.4xlarge": 1.4,
-                  "r2.8xlarge": 2.8,
-                  "m1.small": 0.044,
-                  "m1.medium": 0.087,
-                  "m1.large": 0.175,
-                  "m1.xlarge": 0.35,
-                  "m2.xlarge": 0.245,
-                  "m2.2xlarge": 0.49,
-                  "m2.4xlarge": 0.98,
-                  "m3.medium": 0.07,
-                  "m3.large": 0.14,
-                  "m3.xlarge": 0.28,
-                  "m3.2xlarge": 0.56,
-                  "t1.micro": 0.02,
-                  "t2.micro": 0.013,
-                  "t2.small": 0.026,
-                  "t2.medium": 0.052
-                }
-              }
+import price_table_builder
 
 
 
-def getBurnRate(region, instance):
+class _PriceTable(object):
+  _CACHE_FILE_PATH = "/tmp/burnrate_instance_price_table.json"
+  _MAX_CACHE_AGE_SEC = (24 * 3600)
+
+  # Price table singleton in format returned by `price_table_builder.load()`
+  _priceTableSingleton = None
+
+
+  @classmethod
+  def getTable(cls):
+    """Return price table, possibly loading it from file and rebuilding cache
+    if needed
+    """
+    if cls._priceTableSingleton is not None:
+      return cls._priceTableSingleton
+
+    needToRebuild = True
+
+    # Check if cache needs to be rebuilt
+    if os.path.exists(cls._CACHE_FILE_PATH):
+      mtime = os.path.getmtime(cls._CACHE_FILE_PATH)
+      if (time.time() - mtime) <= cls._MAX_CACHE_AGE_SEC:
+        needToRebuild = False
+
+    if needToRebuild:
+      # Regnereate the pricing table
+
+      # Create new pricing cache in temp file first, then move to static
+      # location, to minimize window for corruption
+      tempFd, tempPath = tempfile.mkstemp(
+        suffix="burnrate_instance_price_table")
+
+      with os.fdopen(tempFd, "wb") as fileObj:
+        price_table_builder.dump(fileObj)
+
+      shutil.move(tempPath, cls._CACHE_FILE_PATH)
+
+      print >> sys.stderr, "(Re)built {}".format(cls._CACHE_FILE_PATH)
+
+    # Load into memory
+    with open(cls._CACHE_FILE_PATH) as inputFp:
+      cls._priceTableSingleton = price_table_builder.load(inputFp)
+
+    return cls._priceTableSingleton
+
+
+
+
+def getBurnRate(instance):
   if instance.state == "stopped":
     return 0.0
-  # Warning: If this function comes across an instance not in the dictionary,
-  # it will return a rate of $50.00/hr (much higher than any real hourly rate)
-  # which should be recognized by Grok as an anomaly. To fix just update the
-  # COST_MATRIX with the propper rates.
-  return COST_MATRIX.get(region.name, "us-west-2").get(instance.instance_type, 50.00)
+
+  key = (instance.instance_type,
+         instance.region.name,
+         (instance.platform or "linux").lower())
+
+  #warning: If this function comes across an instance not in the dictionary, it
+  #         will return a rate of $50.00/hr (much higher than any real hourly
+  #         rate) which should be recognized by Grok as an anomaly.
+  return _PriceTable.getTable().get(key, {"USD": 50.00})["USD"]
 
 
 
@@ -135,15 +113,14 @@ def getDataByRegions():
           if instance.state == "stopped":
             numStopped += 1
           else:
-            totalByRegion = totalByRegion + getBurnRate(r, instance)
+            totalByRegion = totalByRegion + getBurnRate(instance)
             numRunning += 1
 
-      regionalData.update({"%s" % r.name: {
-                            "burnrate":totalByRegion,
-                            "numberRunningInstances":numRunning,
-                            "numberStoppedInstances":numStopped,
-                            "numberAllInstances":numRunning+numStopped
-                          }})
+      regionalData.update(
+        {"%s" % r.name: {"burnrate":totalByRegion,
+                         "numberRunningInstances":numRunning,
+                         "numberStoppedInstances":numStopped,
+                         "numberAllInstances":numRunning+numStopped}})
     except boto.exception.EC2ResponseError:
       pass
   return regionalData

--- a/price_table_builder.py
+++ b/price_table_builder.py
@@ -1,0 +1,192 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2016, Numenta, Inc.  Unless you have purchased from
+# Numenta, Inc. a separate commercial license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""
+Output EC2 Instance pricing table to stdout as a JSON list. Each element in the
+JSON list is a two-tuple, where the first value key consists
+of (all lower-case): instance type, region, platform; the second value is
+an object with key="USD" and value is the amount per hour in US$.
+
+Example:  [["c1.medium", "ap-northeast-1", "rhel"], {"USD": 0.218}]
+
+Reference https://aws.amazon.com/blogs/aws/new-aws-price-list-api/
+"""
+
+import argparse
+import json
+import sys
+import urllib2
+
+
+
+_DEFAULT_OFFERS_URL = ("https://pricing.us-east-1.amazonaws.com/"
+                       "offers/v1.0/aws/AmazonEC2/current/index.json")
+
+_REGION_NAME_TO_REGION = {
+  "US East (N. Virginia)": "us-east-1",
+  "US West (N. California)": "us-west-1",
+  "US West (Oregon)": "us-west-2",
+  "EU (Ireland)": "eu-west-1",
+  "EU (Frankfurt)": "eu-central-1",
+  "Asia Pacific (Tokyo)": "ap-northeast-1",
+  "Asia Pacific (Seoul)": "ap-northeast-2",
+  "Asia Pacific (Singapore)": "ap-southeast-1",
+  "Asia Pacific (Sydney)": "ap-southeast-2",
+  "South America (Sao Paulo)": "sa-east-1"
+}
+
+
+
+def buildLookupTable(offers):
+  """Build lookup table of instance prices
+
+  :param dict offers: AmazonEC2 offers formatted per
+    https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/index.json
+
+  :returns: dict; each property's key consists of (all lower-case):
+    instance type, region, platform; and the value is a dict with key="USD" and
+    value is the amount per hour in US$. Example:
+    {("c1.medium", "ap-northeast-1", "rhel"): {"USD": 0.218}, ...}
+  """
+  products = offers["products"]
+
+  onDemandTerms = offers["terms"]["OnDemand"]
+
+  priceMap = dict()
+
+  for sku in products.itervalues():
+    if sku.get("productFamily") != "Compute Instance":
+      continue
+
+    attributes = sku["attributes"]
+
+    regionName = str(attributes["location"])
+
+    if regionName == "AWS GovCloud (US)":
+      continue
+
+    instanceType = str(attributes["instanceType"])
+
+    operatingSystem = str(attributes["operatingSystem"]).lower()
+
+    skuId = sku["sku"]
+
+    # Find pricing
+    terms = onDemandTerms[skuId]
+
+    if len(terms) != 1:
+      raise Exception("Unexpected number of terms != 1: {}".format(terms))
+
+    term = terms.values()[0]
+
+    priceDimensions = term["priceDimensions"]
+
+    if len(priceDimensions) != 1:
+      raise Exception("Unexpected number of priceDimensions != 1: {}".format(
+        priceDimensions))
+
+    priceDimension = priceDimensions.values()[0]
+
+    pricesPerUnit = priceDimension["pricePerUnit"]
+
+    if len(pricesPerUnit) != 1:
+      raise Exception(
+        "Unexpected number of pricesPerUnit != 1 in rateCode={}: {}".format(
+          priceDimension["rateCode"], pricesPerUnit))
+
+    currency, amount = pricesPerUnit.items()[0]
+    if currency != "USD":
+      raise Exception("Unexpected currency {} in rateCode {}".format(
+        currency, priceDimension["rateCode"]))
+
+    key = (instanceType, _REGION_NAME_TO_REGION[regionName], operatingSystem)
+    priceMap[key] = {
+      "USD": float(amount)
+    }
+
+
+  return priceMap
+
+
+
+def dump(fp, offersUrl=_DEFAULT_OFFERS_URL):
+  """Download the offers table fromt he given URL, extract the instance pricing
+  info and dump to a file in a format that may be retrieved with `load`
+
+  :params file fp: file object for writing the instance pricing dump.
+  :param str offersUrl: AmazonEC2 pricing offers URL, which may be an Internet "
+    "URL (https://...) or an absolute file path (file:///...).
+  """
+  # Load the offers table
+  response = urllib2.urlopen(offersUrl, timeout=300)
+  offers = json.loads(response.read())
+
+  # Convert map to list, because json can't handle our multi-item keys
+  mapAsList = sorted(buildLookupTable(offers).iteritems())
+
+  json.dump(mapAsList, fp, indent=4)
+
+
+
+def load(fp):
+  """Load the lookup table of instance prices from a file.
+
+  :params file fp: file object for reading JSON dump created by this
+    tool.
+
+  :returns: dict; each property's key consists of (all lower-case):
+    instance type, region, platform; and the value is a dict with key="USD" and
+    value is the amount per hour in US$. Example:
+    {("c1.medium", "ap-northeast-1", "rhel"): {"USD": 0.218}, ...}
+
+  """
+  return {
+    tuple(key) : value for key, value in json.load(fp)
+  }
+
+
+
+def main():
+  """Get AmazonEC2 offers URL from command-line options, load the offers table,
+  parse it, and dump to stdout
+  """
+  parser = argparse.ArgumentParser(description=__doc__)
+
+  parser.add_argument(
+    "--url", type=str, required=False,
+    default=_DEFAULT_OFFERS_URL,
+    metavar="EC2_OFFERS_URL",
+    dest="offersUrl",
+    help="AmazonEC2 pricing offers URL, which may be an Internet URL "
+    "(https://...) or an absolute file path (file:///...). Amazon's URL for "
+    "retrieving the current AmazonEC2 offers is {}".format(_DEFAULT_OFFERS_URL))
+
+  args = parser.parse_args()
+
+  dump(sys.stdout, args.offersUrl)
+
+  # Add a newline
+  sys.stdout.write("\n")
+
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
@scottpurdy This applies the changes from https://github.com/NumentaCorp/grok-projects/pull/247. Since you already reviewed and approved https://github.com/NumentaCorp/grok-projects/pull/247, I am going ahead with the merge.

DEVOPS-97 Created a tool price_table_builder.py for  downloading the pricing info from Amazon and extracting compute instance pricing. Also, loads into dict from its own dump format.

DEVOPS-97 burnrate (re)builds pricing table cache once per 24 hours.